### PR TITLE
bugfix:DashboardPage export default

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -7,7 +7,7 @@ import { TaskForm } from '../../../components/TaskForm'
 import { TaskList } from '../../../components/TaskList'
 import { UserInfo } from '../../../components/UserInfo'
 
-export const DashBoardPage = () => {
+const DashBoardPage = () => {
   const router = useRouter()
   const queryClient = useQueryClient()
   const handleLogout = async () => {


### PR DESCRIPTION
**■対応内容**

1. DashBoardPage のexport設定が default と名前指定とで混在していて、ビルドエラーになっていたので修正（Next.jsのページコンポーネントはdefaultエクスポートしなければいけない）
